### PR TITLE
PDFダウンロード前のインタースティシャル広告オーバーレイを追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,11 +197,75 @@ body {
   }
 }
 
+/* ===== 広告オーバーレイ ===== */
+.ad-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.ad-overlay-card {
+  background-color: var(--color-surface);
+  border-radius: 12px;
+  padding: 32px;
+  width: 90%;
+  max-width: 480px;
+  text-align: center;
+  box-shadow: 0 8px 32px var(--color-shadow);
+}
+
+.ad-overlay-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+}
+
+.ad-overlay-slot {
+  border: 2px dashed var(--color-border);
+  border-radius: 8px;
+  padding: 48px 24px;
+  margin-bottom: 20px;
+}
+
+.ad-overlay-placeholder {
+  color: var(--color-text-secondary);
+  font-size: 14px;
+}
+
+.ad-overlay-countdown {
+  color: var(--color-text-secondary);
+  font-size: 14px;
+}
+
+.ad-overlay-close-btn {
+  background-color: var(--color-primary);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.ad-overlay-close-btn:hover {
+  opacity: 0.85;
+}
+
 /* ===== 印刷時: エディタ・ヘッダーを非表示、プレビューのみ印刷 ===== */
 @media print {
   .site-header,
   .pane-editor,
-  .pane-header {
+  .pane-header,
+  .ad-overlay {
     display: none !important;
   }
 

--- a/src/components/AdOverlay.tsx
+++ b/src/components/AdOverlay.tsx
@@ -1,0 +1,49 @@
+"use client"; // クライアントサイドで動作（カウントダウン・イベント処理）
+
+import { useState, useEffect, useCallback } from "react"; // 状態管理・副作用・コールバック
+
+/** AdOverlay の Props 型定義 */
+interface AdOverlayProps {
+  onClose: () => void; // オーバーレイを閉じた時のコールバック
+}
+
+/** PDF ダウンロード前のインタースティシャル広告オーバーレイ */
+export function AdOverlay({ onClose }: AdOverlayProps) {
+  const [countdown, setCountdown] = useState(5); // カウントダウン秒数（初期値5秒）
+
+  // 1秒ごとにカウントダウンを減らすタイマー
+  useEffect(() => {
+    if (countdown <= 0) return; // 0以下なら停止
+    const timer = setTimeout(() => setCountdown((prev) => prev - 1), 1000); // 1秒後にデクリメント
+    return () => clearTimeout(timer); // クリーンアップ
+  }, [countdown]);
+
+  /** 閉じるボタンのクリックハンドラ */
+  const handleClose = useCallback(() => {
+    onClose(); // 親コンポーネントにクローズを通知
+  }, [onClose]);
+
+  return (
+    <div className="ad-overlay"> {/* 全画面オーバーレイ背景 */}
+      <div className="ad-overlay-card"> {/* 中央カード */}
+        <h2 className="ad-overlay-title">スポンサー</h2> {/* タイトル */}
+
+        {/* 広告プレースホルダー（将来 AdSense 等に差し替え可能） */}
+        <div className="ad-overlay-slot">
+          <p className="ad-overlay-placeholder">広告スペース</p> {/* 仮テキスト */}
+        </div>
+
+        {/* カウントダウン表示 or 閉じるボタン */}
+        {countdown > 0 ? (
+          <p className="ad-overlay-countdown">
+            {countdown} 秒後に閉じることができます… {/* 残り秒数を表示 */}
+          </p>
+        ) : (
+          <button onClick={handleClose} className="ad-overlay-close-btn">
+            閉じて PDF を保存 {/* カウント終了後に有効化されるボタン */}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #3

## 変更内容

PDFダウンロードボタンクリック時に、印刷ダイアログの前にインタースティシャル広告（全画面オーバーレイ）を表示する機能を追加。

### 新規ファイル
- `src/components/AdOverlay.tsx`: 広告オーバーレイコンポーネント（5秒カウントダウン付き）

### 変更ファイル
- `src/components/Editor.tsx`: handlePrint をオーバーレイ表示に変更
- `src/app/globals.css`: オーバーレイのスタイル追加、印刷時の非表示設定

### 仕様
- 全画面オーバーレイ（半透明背景 + 中央カード）
- 5秒カウントダウン後に「閉じて PDF を保存」ボタンが有効化
- ボタンクリックでオーバーレイを閉じ `window.print()` を実行
- 広告スペースは将来 AdSense 等に差し替え可能な構造